### PR TITLE
Abort processing is validation result is critical.

### DIFF
--- a/DataProcessor/DataProcessor.DataSource.File/FileDataSource.cs
+++ b/DataProcessor/DataProcessor.DataSource.File/FileDataSource.cs
@@ -76,10 +76,13 @@ namespace DataProcessor.DataSource.File
                 return;
             }
 
-            CreateFieldsForRow(row, context);
-            if (context.IsAborted)
+            if (row.ValidationResult == ValidationResultType.Valid || row.ValidationResult == ValidationResultType.Warning)
             {
-                return;
+                CreateFieldsForRow(row, context);
+                if (context.IsAborted)
+                {
+                    return;
+                }
             }
 
             OnAfterProcessRow(processRowEventArgs);

--- a/DataProcessor/DataProcessor.Tests/DataProcessor.Tests.csproj
+++ b/DataProcessor/DataProcessor.Tests/DataProcessor.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <None Remove="TestFiles\balance-missing-header.csv" />
     <None Remove="TestFiles\balance-missing-trailer.csv" />
+    <None Remove="TestFiles\balance-with-header-and-trailer-with-critical-decoder.definition.xml" />
     <None Remove="TestFiles\balance-with-header-and-trailer-with-warnings.definition.xml" />
     <None Remove="TestFiles\balance-with-header-and-trailer.csv" />
     <None Remove="TestFiles\balance-with-header-and-trailer.definition.xml" />
@@ -28,6 +29,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestFiles\balance-missing-trailer.csv">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestFiles\balance-with-header-and-trailer-with-critical-decoder.definition.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestFiles\balance-with-header-and-trailer-with-warnings.definition.xml">

--- a/DataProcessor/DataProcessor.Tests/TestFiles/balance-with-header-and-trailer-with-critical-decoder.definition.xml
+++ b/DataProcessor/DataProcessor.Tests/TestFiles/balance-with-header-and-trailer-with-critical-decoder.definition.xml
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<inputDataDefinition name="Balance" version="1.0" description="Demo file" delimiter="," hasFieldsEnclosedInQuotes="false" frameworkVersion="1.0" createRowJsonEnabled="true">
+  <header>
+    <fields>
+      <field name="RecordType" description="Record Type (Header Row)" decoder="TextDecoder" pattern="HEADER" failValidationResult="Critical" />
+      <field name="CreationDate" description="Creation Date" decoder="DateDecoder" pattern="MMddyyyy" failValidationResult="Error" />
+      <field name="LocationID" description="Location ID" decoder="TextDecoder" pattern="[a-zA-Z]{12}" failValidationResult="Error" />
+      <field name="SequenceNumber" description="Sequence Number" decoder="IntegerDecoder" pattern="(?!0{4})[0-9]{4}" failValidationResult="Error">
+        <rules>
+          <rule name="SequenceNumber-MinNumberFieldRule" rule="MinNumberFieldRule" description="Sequence number should equal or greater than 1" args="{'ruleValue':'1'}" failValidationResult="Warning" />
+          <rule name="SequenceNumber-MaxNumberFieldRule" rule="MaxNumberFieldRule" description="Sequence number should be equal or less than 100" args="{'ruleValue':'100'}" failValidationResult="Error" />
+        </rules>
+      </field>
+    </fields>
+  </header>
+  <data>
+    <fields>
+      <field name="RecordType" description="Record Type (Data Row)" decoder="TextDecoder" pattern="BALANCE" failValidationResult="Error" />
+      <field name="ConsumerID" description="Consumer ID" decoder="IntegerDecoder" pattern="[0-9]{1,10}" failValidationResult="Error" />
+      <field name="SSN" description="SSN" decoder="TextDecoder" pattern="\d{3}-\d{2}-\d{4}" failValidationResult="Error" />
+      <field name="FirstName" description="First Name" decoder="TextDecoder" pattern="[a-zA-Z0-9\s-']{2,35}" failValidationResult="Error" />
+      <field name="LastName" description="LastName" decoder="TextDecoder" pattern="[a-zA-Z0-9\s-']{2,35}" failValidationResult="Error" />
+      <field name="DOB" description="DOB" decoder="DateDecoder" pattern="MMddyyyy" failValidationResult="Error" />
+      <field name="Balance" description="Amount" decoder="DecimalDecoder" pattern="-{0,1}[0-9]{1,10}\.[0-9]{2}" failValidationResult="Error">
+        <aggregators>
+          <aggregator name="BalanceAggregator" description="Balance aggregator" aggregator="SumAggregator" />
+          <aggregator name="DataRowCountAggregator" description="Data row counter" aggregator="RowCountAggregator" />
+        </aggregators>
+      </field>
+      <field name="CustomField" description="Custom Field without validation" />
+    </fields>
+  </data>
+  <trailer>
+    <fields>
+      <field name="RecordType" description="Record Type (Trailer Line)" decoder="TextDecoder" pattern="TRAILER" failValidationResult="Error" />
+      <field name="BalanceTotal" description="Balance Total" decoder="DecimalDecoder" pattern="-{0,1}[0-9]{1,10}\.[0-9]{2}" failValidationResult="Error">
+        <rules>
+          <rule name="BalanceTotal-MatchesAggregateRule" rule="MatchesAggregateRule" description="Balance Total is incorrect" args="{'ruleValue':'BalanceAggregator'}" failValidationResult="Warning"/>
+        </rules>
+      </field>
+      <field name="RecordCount" description="Record Count" decoder="IntegerDecoder" pattern="\d{1,5}" failValidationResult="Error">
+        <rules>
+          <rule name="RecordCount-MatchesAggregateRule" rule="MatchesAggregateRule" description="Record Count should match the number data row" args="{'ruleValue':'DataRowCountAggregator'}" failValidationResult="Error" />
+        </rules>
+      </field>
+    </fields>
+  </trailer>
+</inputDataDefinition>

--- a/DataProcessor/DataProcessor/ParsedDataProcessor.cs
+++ b/DataProcessor/DataProcessor/ParsedDataProcessor.cs
@@ -112,6 +112,10 @@ namespace DataProcessor
         {
             e.Context.AllRows.Add(e.Row);
             e.Context.ValidationResult = ParsedDataProcessorHelper.GetMaxValidationResult(e.Context.ValidationResult, e.Row.ValidationResult);
+            if (e.Context.ValidationResult == ValidationResultType.Critical)
+            {
+                e.Context.IsAborted = true;
+            }
 
             if (e.Row.ValidationResult != ValidationResultType.Valid && e.Row.ValidationResult != ValidationResultType.Warning)
             {
@@ -313,7 +317,7 @@ namespace DataProcessor
 
             if (rowProcessorDefinition.FieldProcessorDefinitions.Length != row.RawFields.Length)
             {
-                row.ValidationResult = ValidationResultType.Critical;
+                row.ValidationResult = ValidationResultType.Error;
                 var error = $"{lineType} - The expected number of fields {rowProcessorDefinition.FieldProcessorDefinitions.Length} is not equal to the actual number of fields {row.RawFields.Length}";
                 row.Errors.Add(error);
             }


### PR DESCRIPTION
Use validation result error when a row does not have the expected number of fields.
Create fields for a row only when the validation result does not indicate fails.